### PR TITLE
Feature: once and done

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,go}]
+indent_style = tab
+indent_size = 4
+
+[.gopher]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
-gopher.*.*
+gopherd
+gopherd.*.*
 main
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+gopher.*.*
+main
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ protocol written in [Go](http://golang.org/) initially based on [gogopherd](http
 
     go get -u github.com/peterhellberg/gopher/cmd/gopherd
 
+## Compile
+
+	go build -o gopher.local.native cmd/gopherd/main.go
+
+## Usage
+For a standalone server use the following command to run the server on the localhost under port 7070.
+
+	./gopher.local.native \
+		-host localhost \
+		-port 7070 \
+		-root content
+
+For usage as a CGI script or to just test one call, try the `-once` flag with the request of interest. Provide a `-host` and `-port` as normal because these values are used in the return content.
+
+	./gopher.local.native \
+	    -host localhost \
+	    -port 7070 \
+	    -root content \
+	    -once /README.md
+
 ## License (MIT)
 
 Copyright (c) 2015-2018 [Peter Hellberg](https://c7.se/)

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,10 @@
+# Content
+
+Content in this directory are to simulate gopher content
+
+* example.txt - a basic text file
+* page.txt - links to other things, not sure how this is to work
+* README.md - this document
+
+---
+EOF

--- a/content/example.txt
+++ b/content/example.txt
@@ -1,0 +1,7 @@
+The Quick Brown Fox
+
+Once upon a time there was a quick brown fox.
+
+The quick brown fox jumped over the lazy dogs.
+
+The end

--- a/content/page.txt
+++ b/content/page.txt
@@ -1,0 +1,4 @@
+iInfo page	column	2
+iLinks below	column	2
+0Readme	/content/README.md	gopher://localhost	7070
+0Will Fail	/content/fake.txt	gopher://localhost	7070

--- a/entry.go
+++ b/entry.go
@@ -8,11 +8,11 @@ type Entry struct {
 	Display  string
 	Selector string
 	Hostname string
-	Port     string
+	Port     int
 }
 
 // String returns entry as a Gopher listing formatted string
 func (e Entry) String() string {
-	return fmt.Sprintf("%c%s\t%s\t%s\t%s\r\n",
+	return fmt.Sprintf("%c%s\t%s\t%s\t%d\r\n",
 		e.Type, e.Display, e.Selector, e.Hostname, e.Port)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -7,8 +7,8 @@ func TestEntryString(t *testing.T) {
 		e    Entry
 		want string
 	}{
-		{Entry{'0', "a", "b", "c", "d"}, "0a\tb\tc\td\r\n"},
-		{Entry{'9', "e", "f", "g", "h"}, "9e\tf\tg\th\r\n"},
+		{Entry{'0', "a", "b", "c", 70}, "0a\tb\tc\t70\r\n"},
+		{Entry{'9', "e", "f", "g", 7070}, "9e\tf\tg\t7070\r\n"},
 	} {
 		if got := tt.e.String(); got != tt.want {
 			t.Fatalf(`tt.e.String() = %q, want %q`, got, tt.want)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/peterhellberg/gopher
+
+go 1.21.6
+
+require github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/peterhellberg/gopher
 
 go 1.21.6
-
-require github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c h1:W5ggmS2BIWdowiQHkfteYCx+15ARSfm9hkAk/My7yDM=
-github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c/go.mod h1:Q5hvv4UtldyLDxdgTstaM1/ANrgUzktpKNwixiiU3Y4=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c h1:W5ggmS2BIWdowiQHkfteYCx+15ARSfm9hkAk/My7yDM=
+github.com/peterhellberg/gopher v0.0.0-20180411174100-a1641fa3132c/go.mod h1:Q5hvv4UtldyLDxdgTstaM1/ANrgUzktpKNwixiiU3Y4=

--- a/listing.go
+++ b/listing.go
@@ -72,7 +72,7 @@ func (l Listing) String() string {
 }
 
 // VisitDir appends a dir entry to the list of entries in the listing
-func (l *Listing) VisitDir(name, path, root, host, port string) error {
+func (l *Listing) VisitDir(name, path, root, host string, port int) error {
 	if len(l.entries) == 0 {
 		l.entries = append(l.entries, Entry{}) // sentinel value
 		return nil
@@ -84,7 +84,7 @@ func (l *Listing) VisitDir(name, path, root, host, port string) error {
 }
 
 // VisitFile appends a file entry to the list of entries in the listing
-func (l *Listing) VisitFile(name, path, root, host, port string) {
+func (l *Listing) VisitFile(name, path, root, host string, port int) {
 	t := byte('9') // Binary
 
 	for s, c := range Suffixes {

--- a/listing_test.go
+++ b/listing_test.go
@@ -15,12 +15,12 @@ func TestListingString(t *testing.T) {
 	}{
 		{Listing{}, ""},
 		{Listing{[]Entry{
-			{'0', "Foo", "foo", "test", "70"},
-			{'1', "Bar", "bar", "test", "70"},
+			{'0', "Foo", "foo", "test", 70},
+			{'1', "Bar", "bar", "test", 70},
 		}}, "1Bar\tbar\ttest\t70\r\n0Foo\tfoo\ttest\t70\r\n"},
 		{Listing{[]Entry{
-			{'I', "Baz", "baz", "test2", "7070"},
-			{'1', "Qux", "qux", "test2", "7070"},
+			{'I', "Baz", "baz", "test2", 7070},
+			{'1', "Qux", "qux", "test2", 7070},
 		}}, "1Qux\tqux\ttest2\t7070\r\nIBaz\tbaz\ttest2\t7070\r\n"},
 	} {
 		if got := tt.l.String(); got != tt.want {
@@ -38,18 +38,18 @@ func TestListingVisitDir(t *testing.T) {
 		path    string
 		root    string
 		host    string
-		port    string
+		port    int
 	}{
-		{Listing{}, 1, "\x00\t\t\t\r\n", "", "", "", "", ""},
+		{Listing{}, 1, "\x00\t\t\t0\r\n", "", "", "", "", 0},
 		{Listing{[]Entry{
-			{'0', "Foo", "foo", "test", "70"},
-			{'1', "Bar", "bar", "test", "70"},
+			{'0', "Foo", "foo", "test", 70},
+			{'1', "Bar", "bar", "test", 70},
 		}}, 3, "1Dir\tbaz\texample\t70\r\n",
-			"Dir", "bar/baz", "bar/", "example", "70"},
+			"Dir", "bar/baz", "bar/", "example", 70},
 	} {
 		l := tt.listing
 
-		l.VisitDir("Dir", "bar/baz", "bar/", "example", "70")
+		l.VisitDir("Dir", "bar/baz", "bar/", "example", 70)
 
 		if got, want := len(l.entries), tt.count; got != want {
 			t.Fatalf(`len(l.entries) = %d, want %d`, got, want)
@@ -67,11 +67,11 @@ func TestListingVisitDir(t *testing.T) {
 
 func TestListingVisitFile(t *testing.T) {
 	l := Listing{[]Entry{
-		{'0', "Foo", "foo", "test", "70"},
-		{'1', "Bar", "bar", "test", "70"},
+		{'0', "Foo", "foo", "test", 70},
+		{'1', "Bar", "bar", "test", 7070},
 	}}
 
-	l.VisitFile("File", "bar/baz.png", "bar/", "example", "70")
+	l.VisitFile("File", "bar/baz.png", "bar/", "example", 70)
 
 	if got, want := len(l.entries), 3; got != want {
 		t.Fatalf(`len(l.entries) = %d, want %d`, got, want)

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 # This script exists primary to document the different actions that have been
 # taken to build and use this application

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ source scripts/console.lib.sh
 # Compile a version of the app for a specified operating system and chip set
 function build_for() {
 	cprintln $FYELLOW "Build for $1 on processor $2."
-	GOOS=$1 GOARCH=$2 go build -o gopher.$1.$2 cmd/gopherd/main.go
+	GOOS=$1 GOARCH=$2 go build -o gopherd.$1.$2 cmd/gopherd/main.go
 }
 
 # ##############################################################################
@@ -20,7 +20,7 @@ function build_all() {
 	if [ "$?" = "0" ]
 	then
 		cprintln $FGREEN "Build all binaries"
-		go build -o gopher.local.native cmd/gopherd/main.go
+		go build -o gopherd cmd/gopherd/main.go
 		build_for linux amd64 #intel based linux
 		build_for darwin arm64 #m1 based macs
 		build_for darwin amd64 #intel based macs
@@ -54,10 +54,10 @@ fi
 while getopts bcfhrtvx: opt ; do
     case "${opt}" in
         b) build_all ;;
-        c) go build -o gopher.local.native cmd/gopherd/main.go ;;
+        c) go build -o gopherd cmd/gopherd/main.go ;;
         f) gofmt -d . ;;
         h) usage ;;
-        r) ./gopher.local.native -host localhost -port 7070 -root content ;;
+        r) ./gopherd -host localhost -port 7070 -root content ;;
         t) go test ;;
         v) go vet ./... ;;
         x) echo "${OPTARG}" ;;

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,66 @@
+#!/bin/zsh
+
+# This script exists primary to document the different actions that have been
+# taken to build and use this application
+
+source scripts/console.lib.sh
+
+# Compile a version of the app for a specified operating system and chip set
+function build_for() {
+	cprintln $FYELLOW "Build for $1 on processor $2."
+	GOOS=$1 GOARCH=$2 go build -o gopher.$1.$2 cmd/gopherd/main.go
+}
+
+# ##############################################################################
+
+# Build all supported binaries
+function build_all() {
+	cprint $FGREEN "Check that the app passes tests"
+	go test
+	if [ "$?" = "0" ]
+	then
+		cprintln $FGREEN "Build all binaries"
+		go build -o gopher.local.native cmd/gopherd/main.go
+		build_for linux amd64 #intel based linux
+		build_for darwin arm64 #m1 based macs
+		build_for darwin amd64 #intel based macs
+		build_for windows amd64 #legacy junk computers
+	else
+		cprint $FRED "Test failed:" ; echo "Not building executables"
+	fi
+}
+
+# Print a helpfull manual on flags
+function usage() {
+	printf "Usage:\n"
+	format="%4s %-4s : %s\n"
+	printf "${format}" "Flag" "Arg" "Description"
+	printf "${format}" "----" "----" "----------"
+	printf "${format}" "h" "" "This message"
+	printf "${format}" "b" "" "Build all binaries"
+	printf "${format}" "t" "" "Test everything"
+	printf "${format}" "v" "" "Vet (lint) everything"
+	printf "${format}" "x" "text" "Print a separator"
+}
+
+# ##############################################################################
+
+# Behavior for no parameters
+if [ $# -eq 0 ]; then
+	usage
+	exit 1
+fi
+
+while getopts bcfhrtvx: opt ; do
+    case "${opt}" in
+        b) build_all ;;
+        c) go build -o gopher.local.native cmd/gopherd/main.go ;;
+        f) gofmt -d . ;;
+        h) usage ;;
+        r) ./gopher.local.native -host localhost -port 7070 -root content ;;
+        t) go test ;;
+        v) go vet ./... ;;
+        x) echo "${OPTARG}" ;;
+        *) cprintln $FRED "Unknown flag" ; usage ;;
+    esac
+done

--- a/scripts/console.lib.sh
+++ b/scripts/console.lib.sh
@@ -1,0 +1,81 @@
+################################################################################
+# An overly simple set of functions for displaying color and style in a console
+################################################################################
+
+# Wrap a color number in a terminal escape sequence
+function colorwrap() {
+	color=$1
+	printf "\033[0;${color}m"
+}
+
+function stylewrap() {
+	style=$1
+	printf "\033[${style}m"
+}
+
+################################################################################
+# With 8 colors you can support the color models:
+# RGB (light), RYG (traffic lights), CMYK (printing)
+
+# FOREGROUND 					; background
+# ----------------------------- ; -----------------------------
+BLACK=30 						; black=40
+RED=31 							; red=41
+GREEN=32 						; green=42
+YELLOW=33						; yellow=43
+BLUE=34							; blue=44
+MAGENTA=35 						; magenta=45
+CYAN=36 						; cyan=46
+WHITE=37 						; white=47
+
+# Escaped colors
+FBLACK=$(colorwrap $BLACK)		; BBLACK=$(colorwrap $black)
+FRED=$(colorwrap $RED)			; BRED=$(colorwrap $red)
+FGREEN=$(colorwrap $GREEN)		; BGREEN=$(colorwrap $green)
+FYELLOW=$(colorwrap $YELLOW)	; BYELLOW=$(colorwrap $yellow)
+FBLUE=$(colorwrap $BLUE) 		; BBLUE=$(colorwrap $blue)
+FMAGENTA=$(colorwrap $MAGENTA)	; BMAGENTA=$(colorwrap $magenta)
+FCYAN=$(colorwrap $CYAN) 		; BCYAN=$(colorwrap $cyan)
+FWHITE=$(colorwrap $WHITE) 		; BWHITE=$(colorwrap $white)
+
+# Style codes and their escaped values
+nc=0 		; NC=$(stylewrap ${nc})
+bold=1 		; BOLD=$(stylewrap ${bold})
+faint=2		; FAINT=$(stylewrap ${faint})
+italix=3	; ITALIX=$(stylewrap ${italix})		# not well supported
+under=4 	; UNDER=$(stylewrap ${under})
+blink=5 	; BLINK=$(stylewrap ${blink})
+fast=6 		; FAST=$(stylewrap ${fast})			# not well supported
+inverse=7 	; INVERSE=$(stylewrap ${inverse})
+
+# Color print with style using just color numbers
+function cprints() {
+	color=$1	# Example: $RED
+	bg=$2		# Example: $green
+	style=$3	# Example: $bold
+	msg="$4"
+	printf "\033[${color};${bg};${style}m%s\033[0m" "$msg"
+}
+
+# Color print with style followed by a new line
+function cprintsln() {
+	cprints "$1" "$2"
+	echo
+}
+
+# Color print, can mix styles, but can not mix foreground and background
+function cprint() {
+	color="$1"
+	msg="$2"
+	if tty -s ; then
+		printf "${color}%s${NC}" "$msg"
+	else
+		printf "%s" "$msg"
+	fi
+}
+
+# Color print followed by a new line
+function cprintln() {
+	cprint "$1" "$2"
+	echo
+}

--- a/scripts/console.lib.sh
+++ b/scripts/console.lib.sh
@@ -1,5 +1,7 @@
 ################################################################################
 # An overly simple set of functions for displaying color and style in a console
+# By Thomas.Cherry@gmail.com
+# Simply copy into any project to add color.
 ################################################################################
 
 # Wrap a color number in a terminal escape sequence
@@ -8,6 +10,7 @@ function colorwrap() {
 	printf "\033[0;${color}m"
 }
 
+# Wrap a style number in a terminal escape sequence
 function stylewrap() {
 	style=$1
 	printf "\033[${style}m"
@@ -28,7 +31,7 @@ MAGENTA=35 						; magenta=45
 CYAN=36 						; cyan=46
 WHITE=37 						; white=47
 
-# Escaped colors
+# Escaped colors, F for foreground, B for background
 FBLACK=$(colorwrap $BLACK)		; BBLACK=$(colorwrap $black)
 FRED=$(colorwrap $RED)			; BRED=$(colorwrap $red)
 FGREEN=$(colorwrap $GREEN)		; BGREEN=$(colorwrap $green)
@@ -47,6 +50,9 @@ under=4 	; UNDER=$(stylewrap ${under})
 blink=5 	; BLINK=$(stylewrap ${blink})
 fast=6 		; FAST=$(stylewrap ${fast})			# not well supported
 inverse=7 	; INVERSE=$(stylewrap ${inverse})
+
+################################################################################
+# Functions for use externally
 
 # Color print with style using just color numbers
 function cprints() {

--- a/scripts/gwrap.cgi
+++ b/scripts/gwrap.cgi
@@ -16,7 +16,7 @@ fi
 printf "Content-Type: text/text\n"
 printf "X-Script-Name: $SCRIPT_NAME\n"
 printf "X-Query-Name: $QUERY_STRING\n"
-printf "X-Powered-By: Thomas version of CGI Gopher\n"
+printf "X-Powered-By: CGI Gopher\n"
 printf "\n"
 
 ./gopher \

--- a/scripts/gwrap.cgi
+++ b/scripts/gwrap.cgi
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#This is an example CGI script which can be made executable to Apache for running
+#the gopher server one page at a time
+
+if [ "$QUERY_STRING" = "" ] ; then
+    QUERY_STRING='/'
+fi
+
+if [ "$HTTPS" = "on" ] ; then
+    http="https"
+else
+    http="http"
+fi
+
+printf "Content-Type: text/text\n"
+printf "X-Script-Name: $SCRIPT_NAME\n"
+printf "X-Query-Name: $QUERY_STRING\n"
+printf "X-Powered-By: Thomas version of CGI Gopher\n"
+printf "\n"
+
+./gopher \
+	-host "$http://$HTTP_HOST$SCRIPT_NAME?" \
+	-port $SERVER_PORT \
+	-root ../gopher \
+	-once "$QUERY_STRING"

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package gopher
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -14,20 +15,20 @@ import (
 type Server struct {
 	Logger *log.Logger
 	Host   string
-	Port   string
+	Port   int
 	Addr   string
 	Root   string
 }
 
 // ListenAndServe starts listening
 func (s *Server) ListenAndServe() error {
-	l, err := net.Listen("tcp", s.Host+":"+s.Port)
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.Host, s.Port))
 	if err != nil {
 		return err
 	}
 
-	s.Logger.Printf("Listening on gopher://%s:%s\n",
-		s.Host, s.Port)
+	s.Logger.Printf("Listening on gopher://%s:%d and serving files from %s.\n",
+		s.Host, s.Port, s.Root)
 
 	for {
 		c, err := l.Accept()
@@ -45,20 +46,27 @@ func (s *Server) Serve(c *net.TCPConn) {
 
 	p, err := s.getPath(c)
 	if err != nil {
-		fmt.Fprint(c, s.ErrorListing("invalid request"))
+		s.Logger.Print(s.ErrorListing("invalid request"))
 
 		return
 	}
 
+	s.Logger.Printf("Request for %s.", p)
+	output := s.ServeFile(c, p)
+	fmt.Fprint(c, output)
+}
+
+func (s *Server) ServeFile(c io.Writer, p string) string {
 	fn := s.filename(p)
 
 	fi, err := os.Stat(fn)
 	if err != nil {
 		fmt.Fprint(c, s.ErrorListing("not found"))
-
-		return
+		//no output, it's an error
+		return "3'Error'\tFile not found\terror.host\t1"
 	}
 
+	//directories
 	if fi.IsDir() {
 		var list Listing
 
@@ -66,25 +74,28 @@ func (s *Server) Serve(c *net.TCPConn) {
 			if info.IsDir() {
 				return list.VisitDir(info.Name(), path, s.Root, s.Host, s.Port)
 			}
-
 			list.VisitFile(info.Name(), path, s.Root, s.Host, s.Port)
 
 			return nil
 		})
-
-		fmt.Fprint(c, list)
-
-		return
+		return list.String()
 	}
 
+	//files
 	f, err := os.Open(fn)
 	if err != nil {
-		fmt.Fprint(c, s.ErrorListing("couldn't open file"))
-		return
+		s.Logger.Print(s.ErrorListing("couldn't open file"))
+		return "3'Error'\tCould not open file\terror.host\t1"
 	}
 	defer f.Close()
 
-	c.ReadFrom(f)
+	buffer := bytes.Buffer{}
+	_, err = buffer.ReadFrom(f)
+	if err != nil {
+		s.Logger.Print(err)
+		return "3'Error'\tError Reading File\terror.host\t1"
+	}
+	return buffer.String()
 }
 
 // ErrorListing creates an error listing

--- a/server_test.go
+++ b/server_test.go
@@ -9,7 +9,7 @@ func TestServerErrorListing(t *testing.T) {
 	s := &Server{}
 	l := s.ErrorListing("test error")
 
-	if got, want := l.String(), "\x03test error\t\t\t\r\n"; got != want {
+	if got, want := l.String(), "\x03test error\t\t\t0\r\n"; got != want {
 		t.Fatalf(`s.ErrorListing("test error").String() = %q, want %q`, got, want)
 	}
 }


### PR DESCRIPTION
1. Adding a way to make one request and return the response to the console so that the tool can be used as a CGI handler on simple web hosting shell accounts. To use pass a request to the flag -once like this:  `-once /README.md`
2. Exposing a setting for configuring the gopher document root. To use pass `-root <path>` when launching
3. Changing port to a number to enforce more accurate values are used
4. Adding a script to document things, sample content, a wrapper CGI script.